### PR TITLE
Metadata init by default

### DIFF
--- a/lib/src/model/gpx.dart
+++ b/lib/src/model/gpx.dart
@@ -9,7 +9,7 @@ import 'wpt.dart';
 class Gpx {
   String version = '1.1';
   String creator = '';
-  Metadata metadata;
+  Metadata metadata = new Metadata();
   List<Wpt> wpts = [];
   List<Rte> rtes = [];
   List<Trk> trks = [];


### PR DESCRIPTION
Avoid the following error when doing something like this :
var gpx = Gpx();
gpx.creator = "<CREATOR>";
gpx.metadata.time = new DateTime.now();

Raised error :
The setter 'time=' was called on null.
Receiver: null

The current workaround is to init manually the metadata object :
var gpx = Gpx();
gpx.creator = "<CREATOR>";
gpx.metadata = new Metadata();
gpx.metadata.time = new DateTime.now();