### PR TITLE
fix no-element exception when href is absent

### DIFF
--- a/lib/src/gpx_reader.dart
+++ b/lib/src/gpx_reader.dart
@@ -439,9 +439,11 @@ class GpxReader {
     final elm = iterator.current;
 
     if (elm is XmlStartElementEvent) {
-      link.href = elm.attributes
-          .firstWhere((attr) => attr.name == GpxTagV11.href)
-          .value;
+      final hrefs = elm.attributes.where((attr) => attr.name == GpxTagV11.href);
+
+      if (hrefs.isNotEmpty) {
+        link.href = hrefs.first.value;
+      }
     }
 
     if ((elm is XmlStartElementEvent) && !elm.isSelfClosing) {


### PR DESCRIPTION
Description:

Issue: Currently, the GPX reader crashes when it encounters a GPX link (<link>) element without an href attribute.

Proposed Solution: This PR introduces a safeguard against such scenarios. Instead of crashing, the reader will now handle missing href attributes gracefully.

Implementation Details:

Added a check for the presence of the href attribute in a GPX link.
- If href is present, the reader behaves as usual, extracting its first value.
- If href is absent, the reader will not attempt to access it, avoiding a crash. This is seamless as our default href parameter is already set to an empty string ('').

Benefit: This change enhances the robustness of the GPX reader, allowing it to process GPX files with missing href attributes in links without failing.