### PR TITLE
Fix: Change tag order to comply with GPX 1.1 schema (ele before time)

### DIFF
--- a/lib/src/gpx_writer.dart
+++ b/lib/src/gpx_writer.dart
@@ -222,9 +222,9 @@ class GpxWriter {
           _writeAttribute(builder, GpxTagV11.latitude, wpt.lat);
           _writeAttribute(builder, GpxTagV11.longitude, wpt.lon);
 
-          _writeElementWithTime(builder, GpxTagV11.time, wpt.time);
-
           _writeElement(builder, GpxTagV11.elevation, wpt.ele);
+
+          _writeElementWithTime(builder, GpxTagV11.time, wpt.time);
           _writeElement(
             builder,
             GpxTagV11.fix,


### PR DESCRIPTION
Some applications don't open gpx files in which the ele tag does not precede the time tag.